### PR TITLE
Improve reconnect logic and add option to not retry on bad statuses

### DIFF
--- a/client-samples/python/websockets/README.md
+++ b/client-samples/python/websockets/README.md
@@ -39,6 +39,7 @@ Create a file, config.json, with the following properties:
  - `url`: The WebSocket URL to call. **NOTE** in a production app you probably won't source the URL like this, but this is just an example.
  - `requests_ca_bundle`: The file to use as the CA bundle when verifying HTTPS certificates. If omitted, use the default bundle shipped with the `requests` library. Please see the [SSL validation section](#ssl-validation-issues-and-the-requests-ca-bundle) for more details.
  - `disable_ssl_verification`: Explicitly disable SSL verification. **Not recommended for security reasons.**
+ - `retry_bad_handshake_status`: Whether or not to retry if the downstream API returns a handshake status other than 101 Switching Protocols. This may indicate an outage on the API and you may not always want to retry in this situation. Default value is `true`.
 
 You may use [`config-example.json`](./config-example.json) as a starting point.
 

--- a/client-samples/python/websockets/config-example.json
+++ b/client-samples/python/websockets/config-example.json
@@ -8,5 +8,6 @@
   "tenant": "api.morganstanley.com",
   "proxy_host": "PROXY HOST HERE",
   "proxy_port": "PROXY PORT",
-  "url": "wss://ws.api.morganstanley.com/websocket-example"
+  "url": "wss://ws.api.morganstanley.com/websocket-example",
+  "retry_bad_handshake_status": true
 }


### PR DESCRIPTION
Improves the handling of reconnects by properly cleaning up resources if it closes erroneously.
Also adds a flag to optionally prevent reconnects if the server returns a non-101 status code on the handshake.
This may indicate a legitimate failure case where reconnects are not desired.