### PR TITLE
Added OkHttpClient API call for auth check

### DIFF
--- a/client-samples/java/rest/README.md
+++ b/client-samples/java/rest/README.md
@@ -13,6 +13,15 @@ Below are the example services we have configured:
 
 The `ExampleApplication.java` file shows how to use the MsRetrofitWrapper and makes a GET request to the `services` endpoint.
 
+## MsRetrofitWrapper
+This class wraps the MSAL authorization and retrofit code. 
+
+It is recommended that you take the following steps:
+- Configure the microprofile-config.properties file
+- Test authorization using the `checkAuthorisation` method.
+- Configure the retrofit service, to fit the response body of the API that you are calling.
+- Call the API and load into an object using your retrofit service.
+
 ## Running the Java Client application
 It is important to ensure that the Java SDK is installed and the `JAVA_HOME` environment variable has been set.
 This can be checked by performing the following:

--- a/client-samples/java/rest/build.gradle.kts
+++ b/client-samples/java/rest/build.gradle.kts
@@ -9,6 +9,7 @@ version = "1.0-SNAPSHOT"
 dependencies {
     implementation(group="com.google.guava", name="guava", version="${property("googleGuavaVersion")}")
     implementation(group="com.microsoft.azure", name="msal4j", version="${property("microsoftAzureMsal4jVersion")}")
+    implementation(group="com.auth0", name="java-jwt", version="${property("auth0JavaJwtVersion")}")
 
     // okhttp/retrofit
     implementation(group="com.squareup.okhttp3", name="logging-interceptor", version="${property("squareupOkhttp3Version")}")

--- a/client-samples/java/rest/gradle.properties
+++ b/client-samples/java/rest/gradle.properties
@@ -1,5 +1,6 @@
 googleGuavaVersion=33.3.1-jre
 microsoftAzureMsal4jVersion=1.17.3
+auth0JavaJwtVersion=4.4.0
 squareupOkhttp3Version=4.11.0
 squareupRetrofit2Version=2.11.0
 slf4jVersion=2.0.16

--- a/client-samples/java/rest/src/main/java/com/ms/infra/example/application/ExampleApplication.java
+++ b/client-samples/java/rest/src/main/java/com/ms/infra/example/application/ExampleApplication.java
@@ -14,6 +14,7 @@ import retrofit2.Response;
 
 public class ExampleApplication {
     private static final String helloWorldUrl = "https://api-uat.morganstanley.com/hello/world/v1/";
+    private static final String apiEndpoint = "services/";
     private static final Logger logger = LoggerFactory.getLogger(ExampleApplication.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -24,6 +25,12 @@ public class ExampleApplication {
     public static void run() throws Exception {
         MsRetrofitWrapper msRetrofitWrapper = new MsRetrofitWrapper(helloWorldUrl, HttpLoggingInterceptor.Level.BODY);
         HelloWorldRestService helloWorldRestService = msRetrofitWrapper.createService(HelloWorldRestService.class);
+
+        // Call API and print output
+        // Use this to check authorisation
+        msRetrofitWrapper.checkAuthorisation(apiEndpoint);
+
+        // Call the hello world API and load into an object
         callHelloWorldApi(helloWorldRestService);
     }
 

--- a/client-samples/java/rest/src/main/java/com/ms/infra/example/application/interceptors/AuthHeaderInterceptor.java
+++ b/client-samples/java/rest/src/main/java/com/ms/infra/example/application/interceptors/AuthHeaderInterceptor.java
@@ -1,9 +1,13 @@
 package com.ms.infra.example.application.interceptors;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ms.infra.example.application.morganStanleyServices.MsClientAuthTokenService;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -11,6 +15,11 @@ import java.io.IOException;
  * This class is responsible for generating and adding an authorization token to each API call.
  */
 public class AuthHeaderInterceptor implements Interceptor {
+    /**
+     * Logger
+     */
+    private static final Logger logger = LoggerFactory.getLogger(AuthHeaderInterceptor.class);
+
     /**
      * MsClientAuthTokenService is responsible for generating bearer tokens.
      */
@@ -35,7 +44,11 @@ public class AuthHeaderInterceptor implements Interceptor {
         // add Authorization header to every call with this interceptor
         Request original = chain.request();
         Request.Builder builder = original.newBuilder();
-        builder.header("Authorization", "Bearer " + msClientAuthTokenService.getAccessToken());
+        String token = msClientAuthTokenService.getAccessToken();
+        logger.debug("Retrieved token");
+        DecodedJWT jwt = JWT.decode(token);
+
+        builder.header("Authorization", "Bearer " + token);
         Request request = builder.method(original.method(), original.body())
             .build();
         return chain.proceed(request);

--- a/client-samples/java/rest/src/main/java/com/ms/infra/example/application/morganStanleyServices/MsRetrofitWrapper.java
+++ b/client-samples/java/rest/src/main/java/com/ms/infra/example/application/morganStanleyServices/MsRetrofitWrapper.java
@@ -4,17 +4,28 @@ import com.ms.infra.example.application.config.MicroprofileConfigService;
 import com.ms.infra.example.application.interceptors.AuthHeaderInterceptor;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.logging.HttpLoggingInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import okhttp3.logging.HttpLoggingInterceptor.Level;
+
+import java.io.IOException;
 
 /**
  * This class is responsible for setting up the retrofit instance.
  * It automatically gets the config using the MicroprofileConfigService class and adds authorization interceptor to each API call.
  */
 public class MsRetrofitWrapper {
+    /**
+     * Logging
+     */
+    private static final Logger logger = LoggerFactory.getLogger(MsRetrofitWrapper.class);
+
     /**
      * Configured retrofit instance
      */
@@ -31,6 +42,12 @@ public class MsRetrofitWrapper {
     private static final MicroprofileConfigService MICROPROFILE_CONFIG_SERVICE = new MicroprofileConfigService();
 
     /**
+     * API Url
+     */
+    private final String url;
+
+    private final Level logLevel;
+    /**
      * Constructor
      * @param url API url
      * @param logLevel Log interceptor level
@@ -38,6 +55,8 @@ public class MsRetrofitWrapper {
      */
     public MsRetrofitWrapper(String url, Level logLevel) throws Exception {
         this.msClientAuthTokenService = new MsClientAuthTokenService(MICROPROFILE_CONFIG_SERVICE);
+        this.url = url;
+        this.logLevel = logLevel;
         this.retrofit = new Retrofit.Builder()
             .baseUrl(url)
             .addConverterFactory(JacksonConverterFactory.create())
@@ -50,8 +69,10 @@ public class MsRetrofitWrapper {
      * @param url API url
      * @param okHttpClient pre-configured OkHttp Client
      */
-    public MsRetrofitWrapper(HttpUrl url, OkHttpClient okHttpClient) {
+    public MsRetrofitWrapper(HttpUrl url, OkHttpClient okHttpClient, Level logLevel) {
         this.msClientAuthTokenService = null;
+        this.url = url.toString();
+        this.logLevel = logLevel;
         this.retrofit = new Retrofit.Builder()
             .baseUrl(url)
             .addConverterFactory(JacksonConverterFactory.create())
@@ -93,5 +114,17 @@ public class MsRetrofitWrapper {
      */
     public <T> T createService(Class<T> serviceInterface) {
         return this.getRetrofit().create(serviceInterface);
+    }
+
+    public void checkAuthorisation(String apiEndpoint) throws IOException {
+        Request request = new Request.Builder()
+                .url(this.url + apiEndpoint)
+                .build();
+
+        OkHttpClient httpClient = getOkHttpClient(this.logLevel);
+        // Execute the request and handle the response
+        Response response = httpClient.newCall(request).execute();
+        logger.info("Response code: {}", response.code());
+        logger.info("Response: {}", response.body().toString());
     }
 }

--- a/client-samples/java/rest/src/test/java/com/ms/infra/example/application/TestAuthHeaderInterceptorShould.java
+++ b/client-samples/java/rest/src/test/java/com/ms/infra/example/application/TestAuthHeaderInterceptorShould.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestAuthHeaderInterceptorShould {
     MsClientAuthTokenService msClientAuthTokenServiceMock;
-    private final String MOCK_TOKEN = "mock-token";
+    private final String MOCK_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6InRydWUifQ.MAYCAQACAQA";
 
     @Rule
     public MockWebServer mockServer = new MockWebServer();

--- a/client-samples/java/rest/src/test/java/com/ms/infra/example/application/TestHelloWorldRestServiceShould.java
+++ b/client-samples/java/rest/src/test/java/com/ms/infra/example/application/TestHelloWorldRestServiceShould.java
@@ -6,6 +6,7 @@ import com.ms.infra.example.application.morganStanleyServices.MsRetrofitWrapper;
 import com.ms.infra.example.application.responseTypes.HelloWorldGetServicesResponse;
 import com.ms.infra.example.application.services.HelloWorldRestService;
 import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -18,18 +19,16 @@ import retrofit2.Response;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class TestHelloWorldRestServiceShould {
     private MockWebServer mockWebServer;
     private HelloWorldRestService helloWorldRestService;
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final String EXAMPLE_GET_SERVICE_RESPONSE = "{\"response\":\"value\",\"time\":\"2022-01-01T00:00:00Z\"}";
     private final String MOCK_401_ERROR_RESPONSE = "{ \"statusCode\": 401, \"message\": \"Authentication required\" }";
-    private final String TEST_AUTH_TOKEN = "MOCK_BEARER_TOKEN";
+    private final String TEST_AUTH_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6InRydWUifQ.MAYCAQACAQA";
 
     @BeforeEach
     public void setup_hello_world_rest_service() throws IOException {
@@ -45,7 +44,7 @@ public class TestHelloWorldRestServiceShould {
         OkHttpClient okHttpClient = new OkHttpClient.Builder()
             .addInterceptor(authHeaderInterceptor).build();
 
-        MsRetrofitWrapper msRetrofitWrapper = new MsRetrofitWrapper(mockWebServer.url("/"), okHttpClient);
+        MsRetrofitWrapper msRetrofitWrapper = new MsRetrofitWrapper(mockWebServer.url("/"), okHttpClient, HttpLoggingInterceptor.Level.BODY);
         helloWorldRestService = msRetrofitWrapper.createService(HelloWorldRestService.class);
     }
 


### PR DESCRIPTION
Added API call to help check authorisation. Don't need to configure retrofit service as just uses an OkHttpClient to call the API and print response code and body.

Added logging debugs for JWTs. They are also decoded using JWT library if more information is needed.

In the tests, changed the MOCK_TOKEN to a fake JWT that can be decoded.