### PR TITLE
GitHub Release for individual ZIP templates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Github Release for ZIP templates
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          language: [java, python]
+          type: [rest, websockets]
+    steps:
+        # Step 1: Checkout the repository
+        - name: Checkout repository
+          uses: actions/checkout@v3
+  
+        # Step 2: Create a ZIP archive of the files
+        - name: Create ZIP archive
+          run: |
+            mkdir -p artifacts
+            cd client-samples/${{ matrix.language }}/${{ matrix.type }}
+            zip -r ../../../artifacts/${{ matrix.language }}-${{ matrix.type }}.zip .
+  
+        # Step 3: Upload binaries to release
+        - name: Upload binaries to release
+          uses: svenstaro/upload-release-action@v2
+          with:
+            repo_token: ${{ secrets.GITHUB_TOKEN }}
+            file: artifacts/${{ matrix.language }}-${{ matrix.type }}.zip
+            tag: Templates
+            overwrite: true
+            file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         matrix:
           language: [java, python]
           type: [rest, websockets]
+          sub-type: [rest-okhttp, rest-retrofit]
     steps:
         # Step 1: Checkout the repository
         - name: Checkout repository
@@ -22,8 +23,13 @@ jobs:
         - name: Create ZIP archive
           run: |
             mkdir -p artifacts
-            cd client-samples/${{ matrix.language }}/${{ matrix.type }}
-            zip -r ../../../artifacts/${{ matrix.language }}-${{ matrix.type }}.zip .
+            if [ ${{ matrix.language }} == "java" ]; then
+              cd client-samples/${{ matrix.language }}/${{ matrix.type }}/${{ matrix.sub-type }}
+              zip -r ../../../../artifacts/${{ matrix.language }}-${{ matrix.sub-type }}.zip .
+            else
+              cd client-samples/${{ matrix.language }}/${{ matrix.type }}
+              zip -r ../../../artifacts/${{ matrix.language }}-${{ matrix.type }}.zip .
+            fi
   
         # Step 3: Upload binaries to release
         - name: Upload binaries to release


### PR DESCRIPTION
Added a GitHub release for easy access to individual ZIP templates
- No need to clone entire project, can just download a ZIP of an individual template
- Triggers on push to main
- ZIP for each python/java rest/websockets template